### PR TITLE
fix: use docker compose instead of docker-compose

### DIFF
--- a/cmd/util.go
+++ b/cmd/util.go
@@ -66,7 +66,8 @@ func buildDockerComposeCommand(cfg Config, args ...string) []string {
 	profiles := getComposeProfiles(cfg)
 
 	dockerComposeCmd := []string{
-		"docker-compose",
+		"docker",
+		"compose",
 		"--env-file",
 		"defaults.env",
 	}


### PR DESCRIPTION
Recent versions of docker come with docker compose and this is the preferred way to run it.

For example faced an issue with GitHub actions runner where `docker-compose` is not available and had to hack my way around by doing a `echo -e '#!/bin/bash\ndocker compose $@' | sudo tee /usr/local/bin/docker-compose` to make it available (tried with an alias but failed 😄 )