### PR TITLE
feat: ease git repo integration

### DIFF
--- a/cmd/create-env.go
+++ b/cmd/create-env.go
@@ -67,6 +67,19 @@ func createEnv(envDir string, name string, overwrite bool) (string, error) {
 		}
 	}
 
+	// Create .gitignore file
+	gitignorePath := filepath.Join(envPath, ".gitignore")
+	_, err = os.Stat(gitignorePath)
+	if err != nil && !os.IsNotExist(err) {
+		return "", fmt.Errorf("failed to check .gitignore file: %w", err)
+	}
+	if os.IsNotExist(err) || overwrite {
+		err := renderTemplateToFile(getTemplates(), "templates/global/gitignore", nil, gitignorePath)
+		if err != nil {
+			return "", err
+		}
+	}
+
 	// Template the docker-compose.yaml file
 	dockerComposePath := filepath.Join(envPath, "docker-compose.yaml")
 	_, err = os.Stat(dockerComposePath)

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -24,14 +24,10 @@ type UpCmd struct {
 }
 
 func (c *UpCmd) Run() error {
-	// check if env exists
-	envPath := filepath.Join(c.EnvDir, c.Name)
-	created := false
-	if _, err := os.Stat(envPath); os.IsNotExist(err) {
-		if _, err := createEnv(c.EnvDir, c.Name, c.Overwrite); err != nil {
-			return fmt.Errorf("failed to create environment: %w", err)
-		}
-		created = true
+	// Create or ensure environment is properly set up
+	envPath, err := createEnv(c.EnvDir, c.Name, c.Overwrite)
+	if err != nil {
+		return fmt.Errorf("failed to create/setup environment: %w", err)
 	}
 
 	cfgPath := filepath.Join(envPath, "config.yaml")
@@ -40,7 +36,7 @@ func (c *UpCmd) Run() error {
 		return err
 	}
 
-	if created || !c.NoConfigure {
+	if !c.NoConfigure {
 		if err := configureEnv(cfg, envPath); err != nil {
 			return fmt.Errorf("failed to configure environment: %w", err)
 		}

--- a/templates/global/gitignore
+++ b/templates/global/gitignore
@@ -1,3 +1,8 @@
 *
 !config.yaml
-!docker-compose.yaml
+
+# By default, docker-compose.yaml is ignored and generated automatically.
+# If you need to customize the docker-compose.yaml file for this environment:
+# 1. Uncomment the following line to start tracking your changes
+# 2. Run 'git add docker-compose.yaml' to start tracking your customized version
+# !docker-compose.yaml

--- a/templates/global/gitignore
+++ b/templates/global/gitignore
@@ -1,0 +1,3 @@
+*
+!config.yaml
+!docker-compose.yaml


### PR DESCRIPTION
Arguably by default all the information we need to build a defined environment with workbench is in the `config.yaml`. So when we would want to integrate a defined env into a repo, that is the only file we need to commit.

Right now on identisee https://github.com/scality/identisee/pull/501 I have the `docker-compose.yaml` in the mix, and I can't remove it because we don't try to generate it if it doesn't exist:

```shell
5:55PM INF Configuring environment env/default
5:55PM INF Starting environment command="docker compose --env-file defaults.env --profile base --profile feature-scuba --profile feature-utapi up"
no configuration file provided: not found
s3c-workbench: error: exit status 1
```

So suggesting the following to ease up integration:

- We by default create a `.gitignore` if it doesn't exist, with `config.yaml` being the only file allowed.
- And we call createEnv every time, which will only overwrite if the file does not exist or the `--overwrite` flag has been called. 
- Users can still modify the `.gitignore` to include the `docker-compose.yaml` and make some modification to it if needed.
