### PR TITLE
fix: scuba fails on first boot needing restart

### DIFF
--- a/templates/global/docker-compose.yaml
+++ b/templates/global/docker-compose.yaml
@@ -12,6 +12,12 @@ services:
     image: ${METADATA_S3_IMAGE}
     container_name: workbench-metadata-s3
     network_mode: host
+    healthcheck:
+      test: ["CMD-SHELL", "curl -o /dev/null http://127.0.0.1:9000/_/healthcheck"]
+      interval: 10s
+      retries: 10
+      start_period: 30s
+      timeout: 10s
     volumes:
       - ./config/metadata-s3/config.json:/mnt/standalone_workdir/config.json:ro
     profiles:
@@ -21,6 +27,12 @@ services:
     image: ${METADATA_SCUBA_IMAGE}
     container_name: workbench-metadata-scuba
     network_mode: host
+    healthcheck:
+      test: ["CMD-SHELL", "curl -o /dev/null http://127.0.0.1:19000/_/healthcheck"]
+      interval: 10s
+      retries: 10
+      start_period: 30s
+      timeout: 10s
     volumes:
       - ./config/metadata-scuba/config.json:/mnt/standalone_workdir/config.json:ro
     profiles:
@@ -94,9 +106,14 @@ services:
     restart: on-failure
     network_mode: host
     depends_on:
-      - vault
-      - metadata-scuba
-      - metadata-s3
+      vault:
+        condition: service_healthy
+      setup-scuba:
+        condition: service_completed_successfully
+      metadata-scuba:
+        condition: service_healthy
+      metadata-s3:
+        condition: service_healthy
     environment:
       SUPERVISORD_CONF: 'supervisord.conf'
     profiles:

--- a/templates/scuba/supervisord.conf
+++ b/templates/scuba/supervisord.conf
@@ -7,28 +7,28 @@ loglevel = info
 command = node build/index.js --ingest-daemon --log-id 1 --rpc-client --ingest-probe-port 8851
 stdout_logfile = /logs/ingest_1.log
 redirect_stderr = true
-autorestart = false
+autorestart = true
 autostart = true
 
 [program:ingest_2]
 command = node build/index.js --ingest-daemon --log-id 2 --rpc-client --ingest-probe-port 8852
 stdout_logfile = /logs/ingest_2.log
 redirect_stderr = true
-autorestart = false
+autorestart = true
 autostart = true
 
 [program:ingest_3]
 command = node build/index.js --ingest-daemon --log-id 3 --rpc-client --ingest-probe-port 8853
 stdout_logfile = /logs/ingest_3.log
 redirect_stderr = true
-autorestart = false
+autorestart = true
 autostart = true
 
 [program:query_server]
 command = node build/index.js --query-server --admin-server
 stdout_logfile = /logs/query_server.log
 redirect_stderr = true
-autorestart = false
+autorestart = true
 autostart = true
 priority = 1
 


### PR DESCRIPTION
Scuba service requiring a restart upon boot due to what I believe is some race conditions with other services booting up.