### PR TITLE
Allow loading `--env-dir` and `--name` from environment variables

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -8,6 +8,41 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+type RuntimeConfig struct {
+	EnvDir  string
+	EnvName string
+}
+
+const (
+	DefaultEnvDir  = "./env"
+	DefaultEnvName = "default"
+)
+
+func RuntimeConfigFromFlags(envDir, envName string) RuntimeConfig {
+	if envDir == "" {
+		v := os.Getenv("WORKBENCH_ENV_DIR")
+		if v != "" {
+			envDir = v
+		} else {
+			envDir = DefaultEnvDir
+		}
+	}
+
+	if envName == "" {
+		v := os.Getenv("WORKBENCH_ENV_NAME")
+		if v != "" {
+			envName = v
+		} else {
+			envName = DefaultEnvName
+		}
+	}
+
+	return RuntimeConfig{
+		EnvDir:  envDir,
+		EnvName: envName,
+	}
+}
+
 type Config struct {
 	Global        GlobalConfig      `yaml:"global"`
 	Features      FeatureConfig     `yaml:"features"`

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -43,7 +43,7 @@ func RuntimeConfigFromFlags(envDir, envName string) RuntimeConfig {
 	}
 }
 
-type Config struct {
+type EnvironmentConfig struct {
 	Global        GlobalConfig      `yaml:"global"`
 	Features      FeatureConfig     `yaml:"features"`
 	Cloudserver   CloudserverConfig `yaml:"cloudserver"`
@@ -190,8 +190,8 @@ type RedisConfig struct {
 	LogLevel string `yaml:"log_level"`
 }
 
-func DefaultConfig() Config {
-	return Config{
+func DefaultEnvironmentConfig() EnvironmentConfig {
+	return EnvironmentConfig{
 		Global: GlobalConfig{
 			LogLevel: "info",
 			// Profile:  "default",
@@ -238,8 +238,8 @@ func DefaultConfig() Config {
 	}
 }
 
-func LoadConfig(path string) (Config, error) {
-	cfg := DefaultConfig()
+func LoadEnvironmentConfig(path string) (EnvironmentConfig, error) {
+	cfg := DefaultEnvironmentConfig()
 
 	if path == "" {
 		return cfg, nil
@@ -252,7 +252,7 @@ func LoadConfig(path string) (Config, error) {
 	}
 
 	// Parse the YAML into a temporary config
-	var fileCfg Config
+	var fileCfg EnvironmentConfig
 	if err := yaml.Unmarshal(data, &fileCfg); err != nil {
 		return cfg, fmt.Errorf("failed to parse config file: %w", err)
 	}

--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -13,7 +13,7 @@ type ConfigureCmd struct {
 	Name   string `help:"Name of the environment to create. default: 'default'" short:"n"`
 }
 
-type configGenFunc func(cfg Config, path string) error
+type configGenFunc func(cfg EnvironmentConfig, path string) error
 
 func (c *ConfigureCmd) Run() error {
 	rc := RuntimeConfigFromFlags(c.EnvDir, c.Name)
@@ -21,7 +21,7 @@ func (c *ConfigureCmd) Run() error {
 	configPath := filepath.Join(envPath, "values.yaml")
 
 	// Load the global configuration
-	cfg, err := LoadConfig(configPath)
+	cfg, err := LoadEnvironmentConfig(configPath)
 	if err != nil {
 		return fmt.Errorf("failed to load config: %w", err)
 	}
@@ -49,7 +49,7 @@ func createLogDirectories(envDir string) error {
 	return nil
 }
 
-func configureEnv(cfg Config, envDir string) error {
+func configureEnv(cfg EnvironmentConfig, envDir string) error {
 	log.Info().Msgf("Configuring environment %s", envDir)
 
 	if err := createLogDirectories(envDir); err != nil {
@@ -86,16 +86,16 @@ func configureEnv(cfg Config, envDir string) error {
 	return nil
 }
 
-func generateDefaultsEnv(cfg Config, envDir string) error {
+func generateDefaultsEnv(cfg EnvironmentConfig, envDir string) error {
 	defaultsEnvPath := filepath.Join(envDir, "defaults.env")
 	return renderTemplateToFile(getTemplates(), "templates/global/defaults.env", cfg, defaultsEnvPath)
 }
 
-func generateCloudserverConfig(cfg Config, path string) error {
+func generateCloudserverConfig(cfg EnvironmentConfig, path string) error {
 	return renderTemplateToFile(getTemplates(), "templates/cloudserver/config.json", cfg, filepath.Join(path, "cloudserver", "config.json"))
 }
 
-func generateBackbeatConfig(cfg Config, path string) error {
+func generateBackbeatConfig(cfg EnvironmentConfig, path string) error {
 	templates := []string{
 		"env",
 		"supervisord.conf",
@@ -107,7 +107,7 @@ func generateBackbeatConfig(cfg Config, path string) error {
 	return renderTemplates(cfg, "templates/backbeat", filepath.Join(path, "backbeat"), templates)
 }
 
-func generateVaultConfig(cfg Config, path string) error {
+func generateVaultConfig(cfg EnvironmentConfig, path string) error {
 	templates := []string{
 		"config.json",
 		"create-management-account.sh",
@@ -118,7 +118,7 @@ func generateVaultConfig(cfg Config, path string) error {
 	return renderTemplates(cfg, "templates/vault", filepath.Join(path, "vault"), templates)
 }
 
-func generateScubaConfig(cfg Config, path string) error {
+func generateScubaConfig(cfg EnvironmentConfig, path string) error {
 	templates := []string{
 		"config.json",
 		"create-service-user.sh",
@@ -133,17 +133,17 @@ func generateMetadataConfig(cfg MetadataConfig, path string) error {
 	return renderTemplateToFile(getTemplates(), "templates/metadata/config.json", cfg, filepath.Join(path, "config.json"))
 }
 
-func generateS3MetadataConfig(cfg Config, path string) error {
+func generateS3MetadataConfig(cfg EnvironmentConfig, path string) error {
 	cfgPath := filepath.Join(path, "metadata-s3")
 	return generateMetadataConfig(cfg.S3Metadata, cfgPath)
 }
 
-func generateScubaMetadataConfig(cfg Config, path string) error {
+func generateScubaMetadataConfig(cfg EnvironmentConfig, path string) error {
 	cfgPath := filepath.Join(path, "metadata-scuba")
 	return generateMetadataConfig(cfg.ScubaMetadata, cfgPath)
 }
 
-func generateKafkaConfig(cfg Config, path string) error {
+func generateKafkaConfig(cfg EnvironmentConfig, path string) error {
 	templates := []string{
 		"Dockerfile",
 		"setup.sh",
@@ -156,6 +156,6 @@ func generateKafkaConfig(cfg Config, path string) error {
 	return renderTemplates(cfg, "templates/kafka", filepath.Join(path, "kafka"), templates)
 }
 
-func generateUtapiConfig(cfg Config, path string) error {
+func generateUtapiConfig(cfg EnvironmentConfig, path string) error {
 	return renderTemplateToFile(getTemplates(), "templates/utapi/config.json", cfg, filepath.Join(path, "utapi", "config.json"))
 }

--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -9,14 +9,15 @@ import (
 )
 
 type ConfigureCmd struct {
-	EnvDir string `help:"Directory to create the environment in." required:"" short:"d" default:"./env"`
-	Name   string `help:"Name of the environment to create." required:"" short:"n" default:"default"`
+	EnvDir string `help:"Directory to create the environment in. default: './env'" short:"d"`
+	Name   string `help:"Name of the environment to create. default: 'default'" short:"n"`
 }
 
 type configGenFunc func(cfg Config, path string) error
 
 func (c *ConfigureCmd) Run() error {
-	envPath := filepath.Join(c.EnvDir, c.Name)
+	rc := RuntimeConfigFromFlags(c.EnvDir, c.Name)
+	envPath := filepath.Join(rc.EnvDir, rc.EnvName)
 	configPath := filepath.Join(envPath, "values.yaml")
 
 	// Load the global configuration

--- a/cmd/create-env.go
+++ b/cmd/create-env.go
@@ -23,14 +23,14 @@ func (c *CreateEnvCmd) Run() error {
 		return fmt.Errorf("failed to create environment: %w", err)
 	}
 
-	var cfg Config
+	var cfg EnvironmentConfig
 	if c.WithConfig != "" {
-		cfg, err = LoadConfig(c.WithConfig)
+		cfg, err = LoadEnvironmentConfig(c.WithConfig)
 		if err != nil {
 			return fmt.Errorf("failed to load custom config: %w", err)
 		}
 	} else {
-		cfg, err = LoadConfig(filepath.Join(envPath, "values.yaml"))
+		cfg, err = LoadEnvironmentConfig(filepath.Join(envPath, "values.yaml"))
 		if err != nil {
 			return fmt.Errorf("failed to load config: %w", err)
 		}

--- a/cmd/create-env.go
+++ b/cmd/create-env.go
@@ -9,15 +9,16 @@ import (
 )
 
 type CreateEnvCmd struct {
-	EnvDir            string `help:"Directory to create the environment in." required:"" short:"d" default:"./env"`
-	Name              string `help:"Name of the environment to create." required:"" short:"n" default:"default"`
+	EnvDir            string `help:"Directory to create the environment in. default: './env'" short:"d"`
+	Name              string `help:"Name of the environment to create. default: 'default'" short:"n"`
 	Overwrite         bool   `help:"Overwrite the environment if it already exists." short:"o"`
 	WithConfig        string `help:"Path to a custom configuration file. Replaces the default config." type:"existingfile"`
 	WithDockerCompose string `help:"Path to a custom Docker Compose file. Replaces the default file." type:"existingfile"`
 }
 
 func (c *CreateEnvCmd) Run() error {
-	envPath, err := createEnv(c.EnvDir, c.Name, c.Overwrite, c.WithConfig, c.WithDockerCompose)
+	rc := RuntimeConfigFromFlags(c.EnvDir, c.Name)
+	envPath, err := createEnv(rc.EnvDir, rc.EnvName, c.Overwrite, c.WithConfig, c.WithDockerCompose)
 	if err != nil {
 		return fmt.Errorf("failed to create environment: %w", err)
 	}

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -13,14 +13,15 @@ import (
 )
 
 type DestroyCmd struct {
-	EnvDir  string `help:"Directory containing the environment." required:"" short:"d" default:"./env"`
-	Name    string `help:"Name of the environment to destroy." required:"" short:"n" default:"default"`
+	EnvDir  string `help:"Directory containing the environment. default: './env'" short:"d"`
+	Name    string `help:"Name of the environment to destroy. default: 'default'" short:"n"`
 	Timeout int    `help:"Timeout in seconds for stopping containers." short:"t" default:"10"`
 }
 
 func (c *DestroyCmd) Run() error {
 	// Delete env dir if it exists
-	envPath := filepath.Join(c.EnvDir, c.Name)
+	rc := RuntimeConfigFromFlags(c.EnvDir, c.Name)
+	envPath := filepath.Join(rc.EnvDir, rc.EnvName)
 	if info, err := os.Stat(envPath); err == nil {
 		if !info.IsDir() {
 			return fmt.Errorf("%s exists but is not a directory", envPath)
@@ -51,9 +52,9 @@ func (c *DestroyCmd) Run() error {
 	cmd := exec.CommandContext(ctx, dockerComposeCmd[0], dockerComposeCmd[1:]...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	cmd.Dir = filepath.Join(c.EnvDir, c.Name)
+	cmd.Dir = envPath
 	if err := cmd.Run(); err != nil {
-		if errors.Is(ctx.Err(), context.Canceled)  {
+		if errors.Is(ctx.Err(), context.Canceled) {
 			return nil
 		}
 		return err

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -35,7 +35,7 @@ func (c *DestroyCmd) Run() error {
 	}
 
 	cfgPath := filepath.Join(envPath, "values.yaml")
-	cfg, err := LoadConfig(cfgPath)
+	cfg, err := LoadEnvironmentConfig(cfgPath)
 	if err != nil {
 		return err
 	}

--- a/cmd/down.go
+++ b/cmd/down.go
@@ -13,14 +13,15 @@ import (
 )
 
 type DownCmd struct {
-	EnvDir  string `help:"Directory containing the environment." required:"" short:"d" default:"./env"`
-	Name    string `help:"Name of the environment to stop." required:"" short:"n" default:"default"`
+	EnvDir  string `help:"Directory containing the environment. default: './env'" short:"d"`
+	Name    string `help:"Name of the environment to stop. default: 'default'" short:"n"`
 	Timeout int    `help:"Timeout in seconds for stopping containers." short:"t" default:"10"`
 	Volumes bool   `help:"Remove named volumes declared in the 'volumes' section of the Compose file and anonymous volumes attached to containers." short:"v"`
 }
 
 func (c *DownCmd) Run() error {
-	envPath := filepath.Join(c.EnvDir, c.Name)
+	rc := RuntimeConfigFromFlags(c.EnvDir, c.Name)
+	envPath := filepath.Join(rc.EnvDir, rc.EnvName)
 	info, err := os.Stat(envPath)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -53,7 +54,7 @@ func (c *DownCmd) Run() error {
 	cmd := exec.CommandContext(ctx, dockerComposeCmd[0], dockerComposeCmd[1:]...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	cmd.Dir = filepath.Join(c.EnvDir, c.Name)
+	cmd.Dir = envPath
 	if err := cmd.Run(); err != nil {
 		if errors.Is(ctx.Err(), context.Canceled) {
 			return nil

--- a/cmd/down.go
+++ b/cmd/down.go
@@ -34,7 +34,7 @@ func (c *DownCmd) Run() error {
 	}
 
 	cfgPath := filepath.Join(envPath, "values.yaml")
-	cfg, err := LoadConfig(cfgPath)
+	cfg, err := LoadEnvironmentConfig(cfgPath)
 	if err != nil {
 		return err
 	}

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -13,14 +13,15 @@ import (
 )
 
 type LogsCmd struct {
-	EnvDir string `help:"Directory containing the environment." required:"" default:"./env"`
-	Name   string `help:"Name of the environment to start." required:"" short:"n" default:"default"`
+	EnvDir string `help:"Directory containing the environment. default: './env'" short:"d"`
+	Name   string `help:"Name of the environment to retrieve logs for. default: 'default'" short:"n"`
 	Follow bool   `help:"Follow log output." short:"f"`
 }
 
 func (c *LogsCmd) Run() error {
 	// check if env exists
-	envPath := filepath.Join(c.EnvDir, c.Name)
+	rc := RuntimeConfigFromFlags(c.EnvDir, c.Name)
+	envPath := filepath.Join(rc.EnvDir, rc.EnvName)
 
 	cfgPath := filepath.Join(envPath, "values.yaml")
 	cfg, err := LoadConfig(cfgPath)
@@ -44,10 +45,9 @@ func (c *LogsCmd) Run() error {
 	cmd := exec.CommandContext(ctx, dockerComposeCmd[0], dockerComposeCmd[1:]...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	cmd.Dir = filepath.Join(c.EnvDir, c.Name)
-
+	cmd.Dir = envPath
 	if err := cmd.Run(); err != nil {
-		if errors.Is(ctx.Err(), context.Canceled)  {
+		if errors.Is(ctx.Err(), context.Canceled) {
 			return nil
 		}
 		return err

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -24,7 +24,7 @@ func (c *LogsCmd) Run() error {
 	envPath := filepath.Join(rc.EnvDir, rc.EnvName)
 
 	cfgPath := filepath.Join(envPath, "values.yaml")
-	cfg, err := LoadConfig(cfgPath)
+	cfg, err := LoadEnvironmentConfig(cfgPath)
 	if err != nil {
 		return err
 	}

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -35,7 +35,7 @@ func (c *UpCmd) Run() error {
 	}
 
 	cfgPath := filepath.Join(envPath, "values.yaml")
-	cfg, err := LoadConfig(cfgPath)
+	cfg, err := LoadEnvironmentConfig(cfgPath)
 	if err != nil {
 		return err
 	}

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -51,7 +51,7 @@ func renderTemplateToFile(templates fs.FS, tmplPath string, data any, outPath st
 	return nil
 }
 
-func renderTemplates(cfg Config, srcDir, destDir string, templates []string) error {
+func renderTemplates(cfg EnvironmentConfig, srcDir, destDir string, templates []string) error {
 	templateFS := getTemplates()
 	for _, tmpl := range templates {
 		templatePath := filepath.Join(srcDir, tmpl)
@@ -63,7 +63,7 @@ func renderTemplates(cfg Config, srcDir, destDir string, templates []string) err
 	return nil
 }
 
-func getComposeProfiles(cfg Config) []string {
+func getComposeProfiles(cfg EnvironmentConfig) []string {
 	profiles := []string{"base"}
 
 	if cfg.Features.Scuba.Enabled {
@@ -81,7 +81,7 @@ func getComposeProfiles(cfg Config) []string {
 	return profiles
 }
 
-func buildDockerComposeCommand(cfg Config, args ...string) []string {
+func buildDockerComposeCommand(cfg EnvironmentConfig, args ...string) []string {
 	profiles := getComposeProfiles(cfg)
 
 	dockerComposeCmd := []string{

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -123,7 +123,6 @@ func copyFile(src, dest string) (err error) {
 		}
 	}()
 
-
 	_, err = io.Copy(destination, source)
 	return
 }


### PR DESCRIPTION
- Adds support for loading the environment directory and name from environment variables via RuntimeConfig.
- Renames `Config` to `EnvironmentConfig` to be more clear.
