### PR TITLE
WKBCH-26: Launch vault via node instead of yarn start

### DIFF
--- a/templates/global/docker-compose.yaml
+++ b/templates/global/docker-compose.yaml
@@ -120,7 +120,7 @@ services:
     image: ${VAULT_IMAGE}
     container_name: workbench-vault
     network_mode: host
-    command: sh -c "chmod 400 tests/utils/keyfile && yarn start"
+    command: sh -c "chmod 400 tests/utils/keyfile && node --max-http-header-size=32768 vaultd.js"
     environment:
       VAULT_DB_BACKEND: LEVELDB
     volumes:


### PR DESCRIPTION
## Summary

- Vault 7.89.0 ([scality/Vault#2284](https://github.com/scality/Vault/pull/2284)) ships an `.npmrc` referencing `${NODE_AUTH_TOKEN}` (used only at build time via secret mount). Running `yarn start` at container startup makes yarn read that file and abort with `Failed to replace env in config: ${NODE_AUTH_TOKEN}` since the variable is unset at runtime.
- Production Vault (supervisord) and MetaData (`node bin/...`) both bypass yarn at runtime. This change aligns the workbench vault command with that pattern by invoking `node --max-http-header-size=32768 vaultd.js` directly - this is what `yarn start` resolves to Vault's `package.json`: https://github.com/scality/Vault/blob/819c4992a5d08ab2bb0355654bdd7e222eae16a4/package.json#L59